### PR TITLE
Add KeyMapping section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,19 @@ Usage
 * Enter in Visual Block mode using `<C-v>`. Select the region where the box should be.
 
 * Invoke `:VBox`. This will draw a rectangle. In case, it has a width or a height of 1, it will draw a line.
+
+Key Mapping
+-----------
+
+In a lua function:
+
+```lua
+vim.cmd[[setlocal ve=all]]
+vim.api.nvim_buf_set_keymap(0, "n", "J", "<C-v>j:VBox<cr>", {noremap = true})
+vim.api.nvim_buf_set_keymap(0, "n", "K", "<C-v>k:VBox<cr>", {noremap = true})
+vim.api.nvim_buf_set_keymap(0, "n", "L", "<C-v>l:VBox<cr>", {noremap = true})
+vim.api.nvim_buf_set_keymap(0, "n", "H", "<C-v>h:VBox<cr>", {noremap = true})
+vim.api.nvim_buf_set_keymap(0, "v", "f", ":VBox<cr>", {noremap = true})
+```
+![veenDemo](https://user-images.githubusercontent.com/36175703/130246504-d559f66b-3e2a-4065-90f7-d73bf8147397.gif)
+

--- a/README.md
+++ b/README.md
@@ -32,15 +32,32 @@ Usage
 Key Mapping
 -----------
 
-In a lua function:
+You can map `:VBox` commands to allow different ways of drawing lines. 
+
+This function toggles drawing lines on `HJKL` directional keys to allow for faster diagraming.
 
 ```lua
-vim.cmd[[setlocal ve=all]]
-vim.api.nvim_buf_set_keymap(0, "n", "J", "<C-v>j:VBox<cr>", {noremap = true})
-vim.api.nvim_buf_set_keymap(0, "n", "K", "<C-v>k:VBox<cr>", {noremap = true})
-vim.api.nvim_buf_set_keymap(0, "n", "L", "<C-v>l:VBox<cr>", {noremap = true})
-vim.api.nvim_buf_set_keymap(0, "n", "H", "<C-v>h:VBox<cr>", {noremap = true})
-vim.api.nvim_buf_set_keymap(0, "v", "f", ":VBox<cr>", {noremap = true})
+-- enable or disable keymappings for venn
+function _G.toggle_venn()
+    local venn_enabled = vim.inspect(vim.b.venn_enabled) 
+    if(venn_enabled == "nil") then
+        vim.b.venn_enabled = true
+        vim.cmd[[setlocal ve=all]]
+        -- draw a line on HJKL keystokes
+        vim.api.nvim_buf_set_keymap(0, "n", "J", "<C-v>j:VBox<cr>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "n", "K", "<C-v>k:VBox<cr>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "n", "L", "<C-v>l:VBox<cr>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "n", "H", "<C-v>h:VBox<cr>", {noremap = true})
+        -- draw a box by pressing "f" with visual selection
+        vim.api.nvim_buf_set_keymap(0, "v", "f", ":VBox<cr>", {noremap = true})
+    else
+        vim.cmd[[setlocal ve=]]
+        vim.cmd[[mapclear <buffer>]]
+        vim.b.venn_enabled = nil
+    end
+end
+-- toggle keymappings for venn using <leader>v
+vim.api.nvim_set_keymap('n', '<leader>v', ":lua toggle_venn()<cr>", { noremap = true})
 ```
 ![veenDemo](https://user-images.githubusercontent.com/36175703/130246504-d559f66b-3e2a-4065-90f7-d73bf8147397.gif)
 


### PR DESCRIPTION
I'm curious if you would like to add a "Key Mapping" section to your readme? 
I found it useful to execute VBox commands via HJKL for smooth line drawing.


Preview from Readme: 

Key Mapping
-----------

In a lua function:

```lua
vim.cmd[[setlocal ve=all]]
vim.api.nvim_buf_set_keymap(0, "n", "J", "<C-v>j:VBox<cr>", {noremap = true})
vim.api.nvim_buf_set_keymap(0, "n", "K", "<C-v>k:VBox<cr>", {noremap = true})
vim.api.nvim_buf_set_keymap(0, "n", "L", "<C-v>l:VBox<cr>", {noremap = true})
vim.api.nvim_buf_set_keymap(0, "n", "H", "<C-v>h:VBox<cr>", {noremap = true})
vim.api.nvim_buf_set_keymap(0, "v", "f", ":VBox<cr>", {noremap = true})
```
![veenDemo](https://user-images.githubusercontent.com/36175703/130246504-d559f66b-3e2a-4065-90f7-d73bf8147397.gif)