### PR TITLE
clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,24 +32,24 @@ Usage
 Key Mapping
 -----------
 
-You can map `:VBox` commands to allow different ways of drawing lines. 
+You can map `:VBox` commands to allow different ways of drawing lines.
 
-This function toggles drawing lines on `HJKL` directional keys to allow for faster diagraming.
+Use the following function in your neovim config to toggle drawing lines on `HJKL` directional keys to allow for faster creation of diagrams:
 
 ```lua
--- enable or disable keymappings for venn
-function _G.toggle_venn()
-    local venn_enabled = vim.inspect(vim.b.venn_enabled) 
-    if(venn_enabled == "nil") then
+-- venn.nvim: enable or disable keymappings
+function _G.Toggle_venn()
+    local venn_enabled = vim.inspect(vim.b.venn_enabled)
+    if venn_enabled == "nil" then
         vim.b.venn_enabled = true
         vim.cmd[[setlocal ve=all]]
         -- draw a line on HJKL keystokes
-        vim.api.nvim_buf_set_keymap(0, "n", "J", "<C-v>j:VBox<cr>", {noremap = true})
-        vim.api.nvim_buf_set_keymap(0, "n", "K", "<C-v>k:VBox<cr>", {noremap = true})
-        vim.api.nvim_buf_set_keymap(0, "n", "L", "<C-v>l:VBox<cr>", {noremap = true})
-        vim.api.nvim_buf_set_keymap(0, "n", "H", "<C-v>h:VBox<cr>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "n", "J", "<C-v>j:VBox<CR>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "n", "K", "<C-v>k:VBox<CR>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "n", "L", "<C-v>l:VBox<CR>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "n", "H", "<C-v>h:VBox<CR>", {noremap = true})
         -- draw a box by pressing "f" with visual selection
-        vim.api.nvim_buf_set_keymap(0, "v", "f", ":VBox<cr>", {noremap = true})
+        vim.api.nvim_buf_set_keymap(0, "v", "f", ":VBox<CR>", {noremap = true})
     else
         vim.cmd[[setlocal ve=]]
         vim.cmd[[mapclear <buffer>]]
@@ -57,7 +57,7 @@ function _G.toggle_venn()
     end
 end
 -- toggle keymappings for venn using <leader>v
-vim.api.nvim_set_keymap('n', '<leader>v', ":lua toggle_venn()<cr>", { noremap = true})
+vim.api.nvim_set_keymap('n', '<leader>v', ":lua Toggle_venn()<CR>", { noremap = true})
 ```
 ![veenDemo](https://user-images.githubusercontent.com/36175703/130246504-d559f66b-3e2a-4065-90f7-d73bf8147397.gif)
 


### PR DESCRIPTION
- explain that lua snippet is for user to configure
- remove unnecessary trailing lines
- make global function names begin with upper case
- use <CR> as in all neovim man page examples

closes #9